### PR TITLE
Updated component to work with a dynamic bound value.

### DIFF
--- a/addon/components/set-body-class.js
+++ b/addon/components/set-body-class.js
@@ -3,34 +3,40 @@ import getDOM from '../util/get-dom';
 
 export default Component.extend({
   tagName: '',
-  init() {
+
+  didReceiveAttrs() {
     this._super(...arguments);
-    let body = getDOM(this).body;
-    let attr = body.getAttribute('class');
     let name = this.get('name');
-    if (attr) {
-      let classList = attr.split(/\s+/);
-      if (classList.indexOf(name) === -1) {
-        classList.push(name);
-        body.setAttribute('class', classList.join(' '));
-      }
-    } else {
-      body.setAttribute('class', name);
-    }
+    this._updateBodyClass(this._stashedName, name);
+    this._stashedName = name;
   },
+
   willDestroyElement() {
     this._super(...arguments);
+    let name = this.get('name');
+    this._updateBodyClass(name, null);
+    this._stashedName = null;
+  },
+
+  _updateBodyClass(nameToRemove, nameToSet) {
     let body = getDOM(this).body;
     let attr = body.getAttribute('class');
-    let name = this.get('name');
-    if (attr) {
-      let classList = attr.split(/\s+/);
-      let index = classList.indexOf(name);
-      if (index !== -1) {
-        classList.splice(index, 1);
-        body.setAttribute('class', classList.join(' '));
+    let classList = attr ? attr.split(/\s+/) : [];
+
+    if (nameToSet) {
+      if (classList.indexOf(nameToSet) === -1) {
+        classList.push(nameToSet);
       }
     }
+
+    if (nameToRemove) {
+      let index = classList.indexOf(nameToRemove);
+      if (index !== -1) {
+        classList.splice(index, 1);
+      }
+    }
+
+    body.setAttribute('class', classList.join(' '));
   }
 }).reopenClass({
   positionalParams: ['name']

--- a/fastboot-tests/set-body-class-test.js
+++ b/fastboot-tests/set-body-class-test.js
@@ -5,7 +5,6 @@ const { execFileSync } = require('child_process');
 const { module: Qmodule, test } = require('qunitjs');
 
 Qmodule('Fastboot', function(hooks) {
-
   let fastboot;
 
   hooks.before(async function() {
@@ -13,13 +12,12 @@ Qmodule('Fastboot', function(hooks) {
     fastboot = new FastBoot({
       distPath: 'dist',
       resilient: false
-    })
+    });
   });
 
   test('it works', async function(assert) {
     let page = await fastboot.visit('/');
     let html = await page.html();
-    assert.ok(/<body +class="red-text"/.test(html), 'should find red-text class on body');
-  })
-
+    assert.ok(/<body +class=".*red-text.*"/.test(html), 'should find red-text class on body');
+  });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -2,5 +2,7 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   redText: true,
-  blueBackground: false
+  blueBackground: false,
+  textSize: 'small-text',
+  textSizes: ['small-text', 'medium-text', 'large-text']
 });

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -5,3 +5,13 @@ body.red-text {
 body.blue-background {
     background-color: #6666ff;
 }
+
+body.small-text {
+  font-size: medium;
+}
+body.medium-text {
+  font-size: large;
+}
+body.large-text {
+  font-size: xx-large;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -6,5 +6,15 @@
   {{set-body-class "blue-background"}}
 {{/if}}
 
+{{set-body-class textSize}}
+
 <label>{{input type="checkbox" checked=redText}} Red Text</label>
 <label>{{input type="checkbox" checked=blueBackground}} Blue Background</label>
+<br>
+
+Text Size:
+<select onchange={{action (mut textSize) value="target.value"}}>
+  {{#each textSizes as |textSizeChoice|}}
+    <option value={{textSizeChoice}} >{{textSizeChoice}}</option>
+  {{/each}}
+</select>

--- a/tests/integration/components/set-body-class-test.js
+++ b/tests/integration/components/set-body-class-test.js
@@ -38,4 +38,25 @@ module('Integration | Component | set body class', function(hooks) {
     assert.ok(!document.querySelector('body.hello'), "should not find .hello on body");
   });
 
+  test('bound class works', async function(assert) {
+    assert.expect(3);
+    this.set('dynamicName', 'hello');
+    await render(hbs`{{set-body-class dynamicName}}`);
+    assert.ok(document.querySelector('body.hello'), 'should find .hello on body');
+    this.set('dynamicName', 'howdy');
+    assert.ok(document.querySelector('body.howdy'), 'should find .howdy on body');
+    assert.ok(!document.querySelector('body.hello'), 'should not find .hello on body');
+  });
+
+  test('behaves with undefined', async function(assert) {
+    this.set('dynamicName', undefined);
+    await render(hbs`{{set-body-class dynamicName}}`);
+    assert.ok(!document.querySelector('body.undefined'), 'should not find .undefined on body');
+  });
+
+  test('behaves with null', async function(assert) {
+    this.set('dynamicName', null);
+    await render(hbs`{{set-body-class dynamicName}}`);
+    assert.ok(!document.querySelector('body.null'), 'should not find .null on body');
+  });
 });


### PR DESCRIPTION
This resolves #3 by switching from `init()` to `didReceiveAttrs()` and keeping track of the previously set value.  

It's a single value, so we just use a property to stash the value.  If we didn't want to do even this minimal amount of bookkeeping, we could use something like https://github.com/workmanw/ember-diff-attrs to do it for us.
