### PR TITLE
Allow multiple dynamic classes

### DIFF
--- a/addon/components/set-body-class.js
+++ b/addon/components/set-body-class.js
@@ -22,19 +22,21 @@ export default Component.extend({
     let body = getDOM(this).body;
     let attr = body.getAttribute('class');
     let classList = attr ? attr.split(/\s+/) : [];
-
-    if (nameToSet) {
-      if (classList.indexOf(nameToSet) === -1) {
-        classList.push(nameToSet);
-      }
-    }
-
-    if (nameToRemove) {
-      let index = classList.indexOf(nameToRemove);
+    let namesToSet = nameToSet ? nameToSet.split(/\s+/) : [];
+    let namesToRemove = nameToRemove ? nameToRemove.split(/\s+/) : [];
+    
+    namesToRemove.forEach(name => {
+      let index = classList.indexOf(name);
       if (index !== -1) {
         classList.splice(index, 1);
       }
-    }
+    });
+
+    namesToSet.forEach(name => {
+      if (classList.indexOf(name) === -1) {
+        classList.push(name);
+      }
+    });
 
     body.setAttribute('class', classList.join(' '));
   }


### PR DESCRIPTION
This update allows for multiple dynamic classes. For example, if you have the following class names `full-screen color-scheme-light`  and change it to `full-screen color-scheme-dark`, currently it will continue to append each new class string onto the body classes because the entire string is not a match.  (e.g. `full-screen color-scheme-light full-screen color-scheme-dark`)

Placing the names to remove first ensures that we don't delete a duplicate class name.