### PR TITLE
Allow to use same class name multiple times

### DIFF
--- a/addon/components/set-body-class.js
+++ b/addon/components/set-body-class.js
@@ -1,6 +1,23 @@
 import Component from '@ember/component';
 import getDOM from '../util/get-dom';
 
+let globalClassList = [];
+
+function removeObjects(array, objectsToRemove) {
+  objectsToRemove.forEach(name => {
+    let index = array.indexOf(name);
+    if (index !== -1) {
+      array.splice(index, 1);
+    }
+  });
+}
+
+function addObjects(array, objectsToAdd) {
+  objectsToAdd.forEach(name => {
+    array.push(name);
+  });
+}
+
 export default Component.extend({
   tagName: '',
 
@@ -24,19 +41,13 @@ export default Component.extend({
     let classList = attr ? attr.split(/\s+/) : [];
     let namesToSet = nameToSet ? nameToSet.split(/\s+/) : [];
     let namesToRemove = nameToRemove ? nameToRemove.split(/\s+/) : [];
-    
-    namesToRemove.forEach(name => {
-      let index = classList.indexOf(name);
-      if (index !== -1) {
-        classList.splice(index, 1);
-      }
-    });
 
-    namesToSet.forEach(name => {
-      if (classList.indexOf(name) === -1) {
-        classList.push(name);
-      }
-    });
+    removeObjects(classList, globalClassList);
+
+    removeObjects(globalClassList, namesToRemove);
+    addObjects(globalClassList, namesToSet);
+
+    addObjects(classList, globalClassList);
 
     body.setAttribute('class', classList.join(' '));
   }

--- a/tests/integration/components/set-body-class-test.js
+++ b/tests/integration/components/set-body-class-test.js
@@ -28,6 +28,17 @@ module('Integration | Component | set body class', function(hooks) {
     assert.ok(!document.querySelector('body.goodbye'), "should not find hello goodbye");
   });
 
+  test('doesn’t remove class if it’s still used somewhere else', async function(assert) {
+    assert.expect(2);
+    this.set('showFirst', true);
+    this.set('showSecond', true);
+    await render(hbs`{{#if showFirst}}{{set-body-class "hello"}}{{/if}}{{#if showSecond}}{{set-body-class "hello"}}{{/if}}`);
+    this.set('showFirst', false);
+    assert.ok(document.querySelector('body.hello'), "should find hello body");
+    this.set('showSecond', false);
+    assert.notOk(document.querySelector('body.hello'), "should not find hello body");
+  });
+
   test('removes last class', async function(assert) {
     assert.expect(2);
     this.set('showIt', true);


### PR DESCRIPTION
I found that using same class name multiple times sometimes causes a removal of the class while it should be still active - it happens when you remove previous `{{set-body-class}}` _after_ inserting a new one. In my case it was caused by `liquid-fire` transitions.

Here's my fix. I'm not sure if keeping this global list in this place is elegant enough, but it works. 😄