### PR TITLE
Drop support for Node v4, v6 and v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "8"
-
+  - "10"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "qunitjs": "^2.4.1"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "10.* || 12.* || >= 14.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This should unblock a few dependency updates that rely on newer Node versions

/cc @ef4 