### PR TITLE
Add GitHub Actions config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - 'v*'
+  pull_request:
+  schedule:
+    - cron: '0 3 * * *' # daily, at 3am
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+        with:
+          node-version: 10.x
+          yarn-version: 1.22.5
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint:js
+      - run: yarn ember test
+
+  floating-dependencies:
+    name: Floating Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+        with:
+          node-version: 10.x
+          yarn-version: 1.22.5
+
+      - run: yarn install --no-lockfile
+      - run: yarn ember test
+
+  fastboot:
+    name: Fastboot Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+        with:
+          node-version: 10.x
+          yarn-version: 1.22.5
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn test:fastboot
+
+  try-scenarios:
+    name: "ember-try: ${{ matrix.ember-try-scenario }}"
+    runs-on: ubuntu-latest
+    needs: test
+
+    strategy:
+      fail-fast: true
+      matrix:
+        ember-try-scenario:
+          - ember-lts-2.8
+          - ember-lts-2.12
+          - ember-release
+          - ember-beta
+          - ember-canary
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+        with:
+          node-version: 12.x
+          yarn-version: 1.22.5
+
+      - run: yarn install --frozen-lockfile
+
+      - name: test
+        run: yarn ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup


### PR DESCRIPTION
This should fix/work around #15 and seems to be significantly faster than TravisCI. The config was inspired by the GitHub Actions setup in https://github.com/emberjs/ember-test-helpers.

example run: https://github.com/Turbo87/ember-set-body-class/actions/runs/307034953

/cc @ef4 