### PR TITLE
Drop support for Ember.js v3.8 and v3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario:
-          - ember-lts-3.8
+          - ember-3.10
           - ember-lts-3.12
           - ember-lts-3.16
           - ember-lts-3.20

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,10 +3,10 @@ module.exports = {
   useYarn: true,
   scenarios: [
     {
-      name: 'ember-lts-3.8',
+      name: 'ember-3.10',
       npm: {
         devDependencies: {
-          'ember-source': '~3.8.0',
+          'ember-source': '~3.10.0',
         },
       },
     },


### PR DESCRIPTION
Ember.js v3.10 allows us to use native classes, so let's drop support for these older releases to enable that.