### PR TITLE
CI: Disable broken release channel scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
           - ember-lts-3.12
           - ember-lts-3.16
           - ember-lts-3.20
-          - ember-release
-          - ember-beta
-          - ember-canary
+          # - ember-release
+          # - ember-beta
+          # - ember-canary
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
These scenarios are still using the old bower releases and do not actually test what they're supposed to test. This commit disables them for now until we can fix them.