### PR TITLE
Remove obsolete `eslint-env` directives

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,4 @@
-/* eslint-env node */
+'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function (/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,5 @@
-/* eslint-env node */
+'use strict';
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function (environment) {

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,4 +1,5 @@
-/* eslint-env node */
+'use strict';
+
 module.exports = {
   browsers: ['last 1 Chrome versions'],
 };


### PR DESCRIPTION
We use `overrides` in the ESLint config now, so this should not be necessary anymore