### PR TITLE
Adjust browser targets to transpile optional chaining away

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  browsers: ['last 1 Chrome versions'],
+  browsers: ['last 1 Chrome versions', 'last 1 year'],
 };


### PR DESCRIPTION
Node 10 does not support optional chaining yet, but "Node 10" is apparently not a valid browser target for this file. Instead we're using "last 1 year" to support all browsers released within the last 12 months.

This should hopefully fix CI on master and unblock all of the dependency update PRs.