### PR TITLE
services/body-class: Cancel the scheduled update only on fastboot

### DIFF
--- a/addon/services/body-class.js
+++ b/addon/services/body-class.js
@@ -5,6 +5,7 @@ import { once, cancel } from '@ember/runloop';
 
 export default class BodyClassService extends Service {
   _dom = getOwner(this).lookup('service:-document');
+  _fastboot = getOwner(this).lookup('service:fastboot');
   registrations = new Map();
 
   register(id, classNames) {
@@ -51,6 +52,10 @@ export default class BodyClassService extends Service {
   }
 
   willDestroy() {
-    cancel(this.scheduledRun);
+    if (this._fastboot && this._fastboot.isFastBoot) {
+      // prevent FastBoot from removing the CSS classes
+      // again before the response is sent out
+      cancel(this.scheduledRun);
+    }
   }
 }

--- a/tests/acceptance/test-bleed-test.js
+++ b/tests/acceptance/test-bleed-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Acceptance | CSS class bleeding between tests', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('test 1 sets a class', async function (assert) {
+    assert.dom(document.body).hasNoClass('foo');
+    await render(hbs`{{set-body-class "foo"}}`);
+    assert.dom(document.body).hasClass('foo');
+  });
+
+  test('test 2 ensures that the class is not set anymore', async function (assert) {
+    assert.dom(document.body).hasNoClass('foo');
+  });
+});

--- a/tests/fastboot/set-body-class-test.js
+++ b/tests/fastboot/set-body-class-test.js
@@ -6,7 +6,7 @@ module('Fastboot | set-body-class', function (hooks) {
 
   test('it works', async function (assert) {
     let { htmlDocument } = await visit('/');
-    assert.ok(htmlDocument.body.classList.contains('red-text'));
-    assert.ok(htmlDocument.body.classList.contains('small-text'));
+    assert.dom(htmlDocument.body).hasClass('red-text');
+    assert.dom(htmlDocument.body).hasClass('small-text');
   });
 });


### PR DESCRIPTION
Unconditionally cancelling the update caused CSS classes to bleed between consecutive tests. This PR changes the `willDestroy()` hook to only cancel a pending update when running on FastBoot.

Originally I had planned to just remove the `willDestroy()` hook completely, but it appears as if that causes the FastBoot response to not include any CSS classes at all. Apparently all Ember instance cleanup happens before the response is serialized and sent out.