### PR TITLE
Fix for deprecation: Importing inject from @ember/service

### DIFF
--- a/addon/helpers/set-body-class.js
+++ b/addon/helpers/set-body-class.js
@@ -1,6 +1,8 @@
 import Helper from '@ember/component/helper';
 import { guidFor } from '@ember/object/internals';
-import { inject as service } from '@ember/service';
+import * as emberService from '@ember/service';
+
+const service = emberService.service ?? emberService.inject;
 
 export default class SetBodyClassHelper extends Helper {
   @service bodyClass;


### PR DESCRIPTION
See https://deprecations.emberjs.com/id/importing-inject-from-ember-service/

This is not tested, as I was unable to build the addon in a reliable way, see https://github.com/ef4/ember-set-body-class/issues/241